### PR TITLE
Fixed a function call causing a fatal error on our site.

### DIFF
--- a/src/Tribe/Linked_Posts.php
+++ b/src/Tribe/Linked_Posts.php
@@ -766,7 +766,7 @@ class Tribe__Events__Linked_Posts {
 			if ( ! $linked_post_type_data && has_blocks( $event_id ) ) {
 				$meta_key              = $this->get_meta_key( $linked_post_type );
 				$current_post_id_order = get_post_meta( $event_id, $meta_key, false );
-				$new_post_id_order     = $this->maybe_get_new_order_from_blocks( $event_id, $current_post_id_order );
+				$new_post_id_order     = $this->maybe_get_new_order_from_blocks( $event_id, $linked_post_type, $current_post_id_order );
 
 				$this->maybe_reorder_linked_posts_ids( $event_id, $linked_post_type, $new_post_id_order, $current_post_id_order );
 			}


### PR DESCRIPTION
This is fixes the function call so that it no longer crashes our site. Essentially the call to the function `maybe_get_new_order_from_blocks` was missing an argument at line 769.


Server info and plugins
PHP 8.0
Event Tickets 5.6.3
Event Tickets Plus 5.7.3
The Events Calendar 6.2.0
The Events Calendar Pro 6.2.0

Stacktrace:
```
[16-Aug-2023 12:43:51 UTC] PHP Fatal error:  Uncaught TypeError: Tribe__Events__Linked_Posts::maybe_get_new_order_from_blocks(): Argument #2 ($linked_post_type) must be of type string, array given, called in /srv/www/wp-content/plugins/the-events-calendar/src/Tribe/Linked_Posts.php on line 769 and defined in /srv/www/wp-content/plugins/the-events-calendar/src/Tribe/Linked_Posts.php:989
Stack trace:
#0 /srv/www/wp-content/plugins/the-events-calendar/src/Tribe/Linked_Posts.php(769): Tribe__Events__Linked_Posts->maybe_get_new_order_from_blocks(2364, Array)
#1 /srv/www/wp-content/plugins/the-events-calendar/src/Tribe/API.php(185): Tribe__Events__Linked_Posts->handle_submission(2364, Array)
#2 /srv/www/wp-content/plugins/the-events-calendar/src/Tribe/Meta/Save.php(128): Tribe__Events__API::saveEventMeta(2364, Array, Object(WP_Post))
#3 /srv/www/wp-content/plugins/the-events-calendar/src/Tribe/Meta/Save.php(160): Tribe__Events__Meta__Save->save()
#4 /srv/www/wp-content/plugins/the-events-calendar/src/Tribe/Main.php(2905): Tribe__Events__Meta__Save->maybe_save()
#5 /srv/www/wp-includes/class-wp-hook.php(312): Tribe__Events__Main->addEventMeta(2364, Object(WP_Post))
#6 /srv/www/wp-includes/class-wp-hook.php(334): WP_Hook->apply_filters(NULL, Array)
#7 /srv/www/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#8 /srv/www/wp-includes/post.php(4751): do_action('save_post', 2364, Object(WP_Post), true)
#9 /srv/www/wp-includes/post.php(4853): wp_insert_post(Array, false, true)
#10 /srv/www/wp-admin/includes/post.php(445): wp_update_post(Array)
#11 /srv/www/wp-admin/post.php(227): edit_post()
#12 {main}
  thrown in /srv/www/wp-content/plugins/the-events-calendar/src/Tribe/Linked_Posts.php on line 989
```